### PR TITLE
feat: 添加PDF上传、赛题预览、一键发布、赛题详情markdown文本展示

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,5 @@
 VITE_API_BASE_URL=http://localhost:7777
 VITE_NEW_API_BASE_URL=http://localhost:8080
 VITE_AI_API_BASE_URL=http://localhost:4000
+# PDF 上传/解析请求的超时时间（毫秒），默认 600000（10 分钟）
+VITE_PDF_UPLOAD_TIMEOUT_MS=600000

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,4 +1,6 @@
 interface ImportMetaEnv {
   readonly API_BASE_URL: string;
   readonly NEW_API_BASE_URL: string;
+  /** PDF 上传/解析请求的超时时间（毫秒），默认 600000（10 分钟） */
+  readonly VITE_PDF_UPLOAD_TIMEOUT_MS: string;
 }

--- a/src/components/tasks/TaskForm.vue
+++ b/src/components/tasks/TaskForm.vue
@@ -365,6 +365,7 @@
           placeholder="https://..."
           hint="支持 Bilibili、YouTube 等平台的视频链接"
           persistent-hint
+          :rules="videoUrlRules"
         >
           <template #prepend-inner>
             <v-icon size="small" color="primary">mdi-link-variant</v-icon>
@@ -536,7 +537,7 @@
 import type { TaskFormSubmitData, Topic } from '@/types'
 import type { SpaceCategory } from '@/types'
 
-import { computed, defineEmits, defineProps, ref, toRefs } from 'vue'
+import { computed, ref, toRefs } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { VDateInput } from 'vuetify/labs/VDateInput'
 import { toTypedSchema } from '@vee-validate/zod'
@@ -645,6 +646,20 @@ const [teamLockingPolicy, teamLockingPolicyProps] = defineField('teamLockingPoli
 
 const description = ref(props.initialData?.description || [])
 const videoUrl = ref(props.initialData?.videoUrl || '')
+
+/** videoUrl 输入校验规则：仅允许 http:// 或 https:// 协议，防止 XSS */
+const videoUrlRules = [
+  (v: string) => {
+    if (!v) return true
+    try {
+      const parsed = new URL(v)
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') return true
+    } catch {
+      // fall through
+    }
+    return '请输入有效的 HTTP/HTTPS 链接'
+  },
+]
 
 const pendingSubmissionData = ref<{ descriptionText: string | undefined; values: any } | null>(null)
 

--- a/src/components/tasks/TaskForm.vue
+++ b/src/components/tasks/TaskForm.vue
@@ -345,6 +345,34 @@
       </v-card-text>
     </v-card>
 
+    <!-- 视频链接 -->
+    <v-card flat rounded="lg" class="mb-4 form-card">
+      <v-card-item>
+        <template #prepend>
+          <div class="me-3">
+            <v-avatar color="primary-lighten-5" size="48" class="elevation-0">
+              <v-icon color="primary" size="28">mdi-video-outline</v-icon>
+            </v-avatar>
+          </div>
+        </template>
+        <v-card-title class="text-h5 ps-0">视频链接</v-card-title>
+      </v-card-item>
+
+      <v-card-text class="pt-2">
+        <v-text-field
+          v-model="videoUrl"
+          label="视频链接（选填）"
+          placeholder="https://..."
+          hint="支持 Bilibili、YouTube 等平台的视频链接"
+          persistent-hint
+        >
+          <template #prepend-inner>
+            <v-icon size="small" color="primary">mdi-link-variant</v-icon>
+          </template>
+        </v-text-field>
+      </v-card-text>
+    </v-card>
+
     <div class="d-flex justify-end">
       <slot name="buttons" :is-submitting="isSubmitting">
         <div class="d-flex gap-4">
@@ -616,6 +644,7 @@ const [participantLimit, participantLimitProps] = defineField('participantLimit'
 const [teamLockingPolicy, teamLockingPolicyProps] = defineField('teamLockingPolicy', vuetifyConfig)
 
 const description = ref(props.initialData?.description || [])
+const videoUrl = ref(props.initialData?.videoUrl || '')
 
 const pendingSubmissionData = ref<{ descriptionText: string | undefined; values: any } | null>(null)
 
@@ -650,6 +679,7 @@ const submitFormData = (values: any) => {
     maxTeamSize: submitterType.value === 'TEAM' ? maxTeamSize.value : undefined,
     participantLimit: participantLimit.value || undefined,
     teamLockingPolicy: submitterType.value === 'TEAM' ? teamLockingPolicy.value : undefined,
+    videoUrl: videoUrl.value || undefined,
   }
   emit('submit', submissionData)
 }

--- a/src/components/tasks/TaskForm.vue
+++ b/src/components/tasks/TaskForm.vue
@@ -333,7 +333,19 @@
       </v-card-item>
 
       <v-card-text class="pt-2">
+        <!-- Markdown 格式使用纯文本编辑器 -->
+        <v-textarea
+          v-if="descriptionFormat === 'markdown'"
+          v-model="markdownDescription"
+          label="赛题详情（Markdown 格式）"
+          :rows="10"
+          :max-rows="30"
+          rounded
+          class="markdown-textarea"
+        ></v-textarea>
+        <!-- TipTap JSON 格式使用富文本编辑器 -->
         <TipTapEditor
+          v-else
           ref="descriptionEditor"
           v-model="description"
           output="json"
@@ -564,6 +576,8 @@ const props = withDefaults(
     classificationTopics: Topic[]
     categories?: SpaceCategory[]
     selectedCategoryId?: number
+    descriptionFormat?: 'markdown' | 'tiptap'
+    originalDescription?: string
   }>(),
   {
     initialData: null,
@@ -572,6 +586,8 @@ const props = withDefaults(
     classificationTopics: () => [],
     categories: () => [],
     selectedCategoryId: undefined,
+    descriptionFormat: 'tiptap',
+    originalDescription: '',
   }
 )
 
@@ -644,8 +660,11 @@ const [requireRealName, requireRealNameProps] = defineField('requireRealName', v
 const [participantLimit, participantLimitProps] = defineField('participantLimit', vuetifyConfig)
 const [teamLockingPolicy, teamLockingPolicyProps] = defineField('teamLockingPolicy', vuetifyConfig)
 
-const description = ref(props.initialData?.description || [])
+const description = ref(props.initialData?.description || { type: 'doc', content: [] })
 const videoUrl = ref(props.initialData?.videoUrl || '')
+
+// Markdown 格式的描述内容
+const markdownDescription = ref(props.originalDescription || '')
 
 /** videoUrl 输入校验规则：仅允许 http:// 或 https:// 协议，防止 XSS */
 const videoUrlRules = [
@@ -680,10 +699,24 @@ const submitFormData = (values: any) => {
   const deadlineDate = new Date(values.deadline)
   const registrationStartAtDate = values.registrationStartAt ? new Date(values.registrationStartAt) : null
   deadlineDate.setHours(23, 59, 59, 999)
+
+  // 根据原始格式决定保存的描述内容
+  let savedDescription: string
+  let introText: string
+  if (props.descriptionFormat === 'markdown') {
+    // 如果原始是 markdown 格式，保存纯文本内容
+    savedDescription = markdownDescription.value || ''
+    introText = markdownDescription.value || ''
+  } else {
+    // 如果原始是 TipTap JSON 格式，保存 JSON
+    savedDescription = JSON.stringify(description.value)
+    introText = descriptionText || ''
+  }
+
   const submissionData: TaskFormSubmitData = {
     ...values,
-    description: JSON.stringify(description.value),
-    intro: truncateString(descriptionText || '', 255),
+    description: savedDescription,
+    intro: truncateString(introText, 255),
     registrationStartAt: registrationStartAtDate ? registrationStartAtDate.getTime() : null,
     deadline: deadlineDate.getTime(),
     resubmittable: true,
@@ -773,6 +806,17 @@ const handleCancel = () => {
 
 .tiptap-editor {
   margin-top: 0;
+}
+
+.markdown-textarea :deep(.v-textarea__textarea) {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.markdown-textarea :deep(.v-textarea__field) {
+  min-height: 200px;
 }
 
 .form-card {

--- a/src/network/api/tasks/index.ts
+++ b/src/network/api/tasks/index.ts
@@ -36,6 +36,11 @@ export namespace TasksApi {
   /** PDF 上传/解析请求的超时时间（毫秒），可通过 VITE_PDF_UPLOAD_TIMEOUT_MS 环境变量配置 */
   const PDF_TIMEOUT_MS = Number(import.meta.env.VITE_PDF_UPLOAD_TIMEOUT_MS) || 600000
 
+  /**
+   * 上传 PDF 并解析生成赛题草稿预览
+   * @param data - 包含空间ID、PDF文件、模板参数等的请求数据
+   * @returns 解析出的赛题草稿列表、使用的模板信息及 token 消耗
+   */
   export const previewFromPdf = (data: CreateTaskFromPdfRequestData) => {
     const formData = new FormData()
     formData.append('spaceId', data.spaceId.toString())
@@ -59,6 +64,11 @@ export namespace TasksApi {
     })
   }
 
+  /**
+   * 上传 PDF 并直接创建赛题（跳过预览步骤）
+   * @param data - 包含空间ID、PDF文件、模板参数等的请求数据
+   * @returns 创建成功的赛题对象
+   */
   export const createFromPdf = (data: CreateTaskFromPdfRequestData) => {
     const formData = new FormData()
     formData.append('spaceId', data.spaceId.toString())
@@ -79,6 +89,11 @@ export namespace TasksApi {
     })
   }
 
+  /**
+   * 确认并批量发布 PDF 解析生成的赛题草稿
+   * @param data - 包含待发布草稿列表的请求数据
+   * @returns 已创建的赛题列表和数量
+   */
   export const confirmFromPdf = (data: ConfirmTaskFromPdfRequestData) =>
     NewApiInstance.request<ConfirmTaskFromPdfResponseData>({
       url: '/tasks/publish/from-pdf/confirm',

--- a/src/network/api/tasks/index.ts
+++ b/src/network/api/tasks/index.ts
@@ -33,6 +33,9 @@ import { NEW_API_BASE_URL } from '@/network/utils'
 import AccountService from '@/services/account'
 
 export namespace TasksApi {
+  /** PDF 上传/解析请求的超时时间（毫秒），可通过 VITE_PDF_UPLOAD_TIMEOUT_MS 环境变量配置 */
+  const PDF_TIMEOUT_MS = Number(import.meta.env.VITE_PDF_UPLOAD_TIMEOUT_MS) || 600000
+
   export const previewFromPdf = (data: CreateTaskFromPdfRequestData) => {
     const formData = new FormData()
     formData.append('spaceId', data.spaceId.toString())
@@ -52,7 +55,7 @@ export namespace TasksApi {
       url: '/tasks/publish/from-pdf/preview',
       method: 'POST',
       data: formData,
-      timeout: 300000,
+      timeout: PDF_TIMEOUT_MS,
     })
   }
 
@@ -72,7 +75,7 @@ export namespace TasksApi {
       url: '/tasks/publish/from-pdf',
       method: 'POST',
       data: formData,
-      timeout: 300000,
+      timeout: PDF_TIMEOUT_MS,
     })
   }
 
@@ -81,7 +84,7 @@ export namespace TasksApi {
       url: '/tasks/publish/from-pdf/confirm',
       method: 'POST',
       data,
-      timeout: 300000,
+      timeout: PDF_TIMEOUT_MS,
     })
 
   export const create = (data: PostTaskRequestData) =>

--- a/src/network/api/tasks/index.ts
+++ b/src/network/api/tasks/index.ts
@@ -5,14 +5,19 @@ import type { Task } from '@/types'
 import type {
   AddTaskParticipantRequestData,
   ChatReference,
+  ConfirmTaskFromPdfRequestData,
+  ConfirmTaskFromPdfResponseData,
   ConversationGroupSummary,
   CreateTaskAIAdviceConversationRequest,
+  CreateTaskFromPdfRequestData,
+  CreateTaskFromPdfResponseData,
   PatchTaskParticipantRequestData,
   PatchTaskRequestData,
   PatchTaskSubmissionReviewRequestData,
   PostTaskRequestData,
   PostTaskSubmissionRequestData,
   PostTaskSubmissionReviewRequestData,
+  PreviewTaskFromPdfResponseData,
   TaskAIAdvice,
   TaskAIAdviceConversation,
   TaskAIAdviceConversationContext,
@@ -28,6 +33,57 @@ import { NEW_API_BASE_URL } from '@/network/utils'
 import AccountService from '@/services/account'
 
 export namespace TasksApi {
+  export const previewFromPdf = (data: CreateTaskFromPdfRequestData) => {
+    const formData = new FormData()
+    formData.append('spaceId', data.spaceId.toString())
+    formData.append('file', data.file)
+    formData.append('templateIndex', (data.templateIndex ?? -1).toString())
+    formData.append('maxTasks', (data.maxTasks ?? 5).toString())
+
+    if (data.categoryId !== undefined && data.categoryId !== null) {
+      formData.append('categoryId', data.categoryId.toString())
+    }
+
+    if (data.submitterType) {
+      formData.append('submitterType', data.submitterType)
+    }
+
+    return NewApiInstance.request<PreviewTaskFromPdfResponseData>({
+      url: '/tasks/publish/from-pdf/preview',
+      method: 'POST',
+      data: formData,
+      timeout: 300000,
+    })
+  }
+
+  export const createFromPdf = (data: CreateTaskFromPdfRequestData) => {
+    const formData = new FormData()
+    formData.append('spaceId', data.spaceId.toString())
+    formData.append('file', data.file)
+    formData.append('templateIndex', (data.templateIndex ?? -1).toString())
+    if (data.categoryId !== undefined && data.categoryId !== null) {
+      formData.append('categoryId', data.categoryId.toString())
+    }
+    if (data.submitterType) {
+      formData.append('submitterType', data.submitterType)
+    }
+
+    return NewApiInstance.request<CreateTaskFromPdfResponseData>({
+      url: '/tasks/publish/from-pdf',
+      method: 'POST',
+      data: formData,
+      timeout: 300000,
+    })
+  }
+
+  export const confirmFromPdf = (data: ConfirmTaskFromPdfRequestData) =>
+    NewApiInstance.request<ConfirmTaskFromPdfResponseData>({
+      url: '/tasks/publish/from-pdf/confirm',
+      method: 'POST',
+      data,
+      timeout: 300000,
+    })
+
   export const create = (data: PostTaskRequestData) =>
     NewApiInstance.request<{ task: Task }>({
       url: '/tasks',

--- a/src/network/api/tasks/types.ts
+++ b/src/network/api/tasks/types.ts
@@ -38,6 +38,15 @@ export type PostTaskRequestData = {
   videoUrl?: string
 }
 
+/**
+ * PDF 转赛题请求数据
+ * @property spaceId - 目标空间 ID
+ * @property file - 要上传的 PDF 文件
+ * @property categoryId - 可选的分类 ID
+ * @property templateIndex - 模板索引，-1 表示使用空白模板
+ * @property submitterType - 提交者类型（USER / TEAM）
+ * @property maxTasks - 最大解析赛题数量
+ */
 export type CreateTaskFromPdfRequestData = {
   spaceId: number
   file: File
@@ -47,20 +56,33 @@ export type CreateTaskFromPdfRequestData = {
   maxTasks?: number
 }
 
+/** PDF 直接创建赛题的响应数据 */
 export type CreateTaskFromPdfResponseData = {
   task: Task
 }
 
+/**
+ * PDF 解析预览的响应数据
+ * @property drafts - 解析出的赛题草稿列表
+ * @property templateUsed - 实际使用的模板信息
+ * @property tokenUsed - 本次解析消耗的 token 数量
+ */
 export type PreviewTaskFromPdfResponseData = {
   drafts: PostTaskRequestData[]
   templateUsed: Record<string, any>
   tokenUsed: number
 }
 
+/** 确认发布 PDF 解析草稿的请求数据 */
 export type ConfirmTaskFromPdfRequestData = {
   drafts: PostTaskRequestData[]
 }
 
+/**
+ * 确认发布 PDF 解析草稿的响应数据
+ * @property tasks - 已创建的赛题列表
+ * @property count - 成功创建的赛题数量
+ */
 export type ConfirmTaskFromPdfResponseData = {
   tasks: Task[]
   count: number

--- a/src/network/api/tasks/types.ts
+++ b/src/network/api/tasks/types.ts
@@ -1,4 +1,4 @@
-import type { TaskSubmissionSchemaEntry, TaskSubmitterType, TaskTeamMembershipLockPolicy } from '@/types'
+import type { Task, TaskSubmissionSchemaEntry, TaskSubmitterType, TaskTeamMembershipLockPolicy } from '@/types'
 
 import { ChatContext } from '@/components/chat'
 
@@ -35,6 +35,34 @@ export type PostTaskRequestData = {
   maxTeamSize?: number
   participantLimit?: number
   teamLockingPolicy?: TaskTeamMembershipLockPolicy
+}
+
+export type CreateTaskFromPdfRequestData = {
+  spaceId: number
+  file: File
+  categoryId?: number
+  templateIndex?: number
+  submitterType?: TaskSubmitterType
+  maxTasks?: number
+}
+
+export type CreateTaskFromPdfResponseData = {
+  task: Task
+}
+
+export type PreviewTaskFromPdfResponseData = {
+  drafts: PostTaskRequestData[]
+  templateUsed: Record<string, any>
+  tokenUsed: number
+}
+
+export type ConfirmTaskFromPdfRequestData = {
+  drafts: PostTaskRequestData[]
+}
+
+export type ConfirmTaskFromPdfResponseData = {
+  tasks: Task[]
+  count: number
 }
 
 export type PatchTaskRequestData = {

--- a/src/network/api/tasks/types.ts
+++ b/src/network/api/tasks/types.ts
@@ -35,6 +35,7 @@ export type PostTaskRequestData = {
   maxTeamSize?: number
   participantLimit?: number
   teamLockingPolicy?: TaskTeamMembershipLockPolicy
+  videoUrl?: string
 }
 
 export type CreateTaskFromPdfRequestData = {
@@ -78,6 +79,7 @@ export type PatchTaskRequestData = {
   requireRealName?: boolean
   participantLimit?: number
   teamLockingPolicy?: TaskTeamMembershipLockPolicy
+  videoUrl?: string
 }
 
 export type AddTaskParticipantRequestData = {

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -85,6 +85,7 @@ export interface Task {
   topics?: Topic[]
   userDeadline?: number
   participationEligibility?: ParticipationEligibility
+  videoUrl?: string
 }
 
 export interface TaskSubmissionReview {
@@ -171,4 +172,5 @@ export type TaskFormSubmitData = {
   maxTeamSize: number
   participantLimit?: number
   teamLockingPolicy?: TaskTeamMembershipLockPolicy
+  videoUrl?: string
 }

--- a/src/views/spaces/detail/AuditTask.vue
+++ b/src/views/spaces/detail/AuditTask.vue
@@ -246,10 +246,44 @@ const rejectTask = async (taskId: number) => {
 }
 
 const parseDescription = (description: string) => {
+  if (!description) return { type: 'doc', content: [] }
   try {
-    return JSON.parse(description)
+    const parsed = JSON.parse(description)
+    // 检查是否为 TipTap JSON 格式
+    if (typeof parsed === 'object' && parsed !== null && parsed.type === 'doc') {
+      return parsed
+    }
+    // 如果不是 TipTap 格式，返回原始字符串作为文本内容
+    return {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: description,
+            },
+          ],
+        },
+      ],
+    }
   } catch (error) {
-    return description
+    // JSON 解析失败，说明是 markdown 或纯文本，返回文本内容
+    return {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: description,
+            },
+          ],
+        },
+      ],
+    }
   }
 }
 

--- a/src/views/spaces/detail/PublishTask.vue
+++ b/src/views/spaces/detail/PublishTask.vue
@@ -145,6 +145,7 @@ const pdfConfirmLoading = ref(false)
 const pdfDrafts = ref<Record<string, any>[]>([])
 const pdfTokenUsed = ref<number | null>(null)
 
+/** 当前选中的 PDF 文件（兼容 v-file-input 的单文件或数组返回值） */
 const selectedPdf = computed<File | null>(() => {
   if (Array.isArray(pdfFile.value)) {
     return pdfFile.value[0] ?? null
@@ -152,12 +153,12 @@ const selectedPdf = computed<File | null>(() => {
   return pdfFile.value
 })
 
-// 获取活跃的分类列表
+/** 获取活跃（未归档）的分类列表，按 displayOrder 排序 */
 const activeCategories = computed(() => {
   return categories.value.filter((category) => !category.archivedAt).sort((a, b) => a.displayOrder - b.displayOrder)
 })
 
-// 从URL参数中获取预选的分类ID
+/** 从 URL 查询参数中获取预选的分类 ID，并验证其是否在活跃分类中 */
 const preselectedCategoryId = computed(() => {
   const categoryParam = route.query.categoryId
   if (!categoryParam) return undefined
@@ -167,6 +168,7 @@ const preselectedCategoryId = computed(() => {
   return activeCategories.value.some((cat) => cat.id === categoryId) ? categoryId : undefined
 })
 
+/** 从 URL 查询参数中获取 PDF 解析使用的模板索引，-1 表示空白模板 */
 const pdfTemplateIndex = computed(() => {
   const templateParam = route.query.templateId
   if (!templateParam || templateParam === 'blank') return -1
@@ -194,6 +196,11 @@ const taskSubmissionSchema = ref<TaskSubmissionSchemaEntry[]>([
 //   taskSubmissionSchema.value.splice(index, 1)
 // }
 
+/**
+ * 提交赛题表单，调用 API 创建赛题
+ * @param taskData - 表单填写的赛题数据
+ * @returns 是否提交成功
+ */
 const submitTask = async (taskData: TaskFormSubmitData) => {
   const spaceId = currentSpaceId.value
   if (!spaceId) {
@@ -232,6 +239,10 @@ const submitTask = async (taskData: TaskFormSubmitData) => {
   return result !== undefined
 }
 
+/**
+ * 上传 PDF 并请求后端解析预览
+ * 校验文件大小（≤15MB），调用 previewFromPdf API 获取草稿列表
+ */
 const previewFromPdf = async () => {
   const spaceId = currentSpaceId.value
   if (!spaceId) {
@@ -277,6 +288,10 @@ const previewFromPdf = async () => {
   }
 }
 
+/**
+ * 确认并批量发布 PDF 解析出的赛题草稿
+ * 调用 confirmFromPdf API，成功后跳转到「我发布的」页面
+ */
 const confirmPublishFromPdf = async () => {
   const spaceId = currentSpaceId.value
   if (!spaceId) {
@@ -305,11 +320,17 @@ const confirmPublishFromPdf = async () => {
   }
 }
 
+/** 清空当前的 PDF 预览草稿列表和 token 消耗记录 */
 const clearPdfDrafts = () => {
   pdfDrafts.value = []
   pdfTokenUsed.value = null
 }
 
+/**
+ * 格式化时间戳为本地化日期时间字符串
+ * @param value - 时间戳数值或字符串
+ * @returns 格式化后的日期时间字符串，无效值返回 '-'
+ */
 const formatTimestamp = (value: number | string | null | undefined) => {
   if (!value) return '-'
   const numeric = Number(value)
@@ -335,6 +356,10 @@ onMounted(async () => {
   )
 })
 
+/**
+ * 根据模板 ID 加载模板数据并填充表单初始值
+ * @param templateId - 模板 ID
+ */
 const loadTemplate = async (templateId: number) => {
   const template = templates.value[templateId]
   if (template) {

--- a/src/views/spaces/detail/PublishTask.vue
+++ b/src/views/spaces/detail/PublishTask.vue
@@ -1,5 +1,109 @@
 <template>
   <v-sheet flat rounded="lg">
+    <v-card class="ma-4 mb-4" rounded="lg" variant="outlined">
+      <v-card-item>
+        <template #prepend>
+          <v-avatar color="primary-lighten-5" size="44" class="elevation-0">
+            <v-icon color="primary" size="24">mdi-file-pdf-box</v-icon>
+          </v-avatar>
+        </template>
+        <v-card-title class="text-h6 ps-0">PDF 快速发布</v-card-title>
+        <v-card-subtitle class="ps-0">上传赛题 PDF 后，系统会自动解析并按当前空白模板生成赛题</v-card-subtitle>
+      </v-card-item>
+
+      <v-card-text class="pt-2">
+        <v-file-input
+          v-model="pdfFile"
+          accept=".pdf,application/pdf"
+          label="上传赛题 PDF"
+          variant="outlined"
+          density="comfortable"
+          clearable
+          prepend-icon=""
+          :disabled="pdfPreviewLoading || pdfConfirmLoading"
+          hide-details="auto"
+        >
+          <template #prepend>
+            <v-icon color="primary" class="mr-2">mdi-upload</v-icon>
+          </template>
+          <template #selection="{ fileNames }">
+            <v-chip color="primary" variant="outlined" label class="mt-1">
+              <v-icon start>mdi-file-pdf-box</v-icon>
+              {{ fileNames[0] }}
+            </v-chip>
+          </template>
+        </v-file-input>
+
+        <v-alert class="mt-3" type="info" variant="tonal" density="comfortable" border="start">
+          支持 PDF 文件，单文件大小不超过 15MB。若当前 URL 带有模板参数，会优先使用该模板；否则使用空白模板。
+        </v-alert>
+      </v-card-text>
+
+      <v-card-actions class="px-4 pb-4 pt-0 d-flex justify-end">
+        <v-btn
+          color="primary"
+          :loading="pdfPreviewLoading"
+          :disabled="pdfPreviewLoading || !selectedPdf"
+          @click="previewFromPdf"
+        >
+          <v-icon start>mdi-eye-outline</v-icon>
+          解析预览
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <v-card v-if="pdfDrafts.length > 0" class="ma-4 mb-4" rounded="lg" variant="outlined">
+      <v-card-item>
+        <template #prepend>
+          <v-avatar color="success-lighten-5" size="44" class="elevation-0">
+            <v-icon color="success" size="24">mdi-file-document-multiple-outline</v-icon>
+          </v-avatar>
+        </template>
+        <v-card-title class="text-h6 ps-0">解析预览结果</v-card-title>
+        <v-card-subtitle class="ps-0">
+          共识别 {{ pdfDrafts.length }} 个赛题草稿，可批量确认发布。
+          <span v-if="pdfTokenUsed !== null">本次约消耗 {{ pdfTokenUsed }} tokens</span>
+        </v-card-subtitle>
+      </v-card-item>
+
+      <v-card-text class="pt-0">
+        <v-expansion-panels variant="accordion">
+          <v-expansion-panel v-for="(draft, index) in pdfDrafts" :key="`${index}-${draft.name || 'draft'}`">
+            <v-expansion-panel-title>
+              <div class="d-flex align-center justify-space-between w-100 pr-2">
+                <div class="text-subtitle-2">{{ index + 1 }}. {{ draft.name || '未命名赛题' }}</div>
+                <v-chip size="x-small" color="primary" variant="tonal">{{ draft.submitterType || 'TEAM' }}</v-chip>
+              </div>
+            </v-expansion-panel-title>
+            <v-expansion-panel-text>
+              <div class="text-body-2 mb-2"><strong>简介：</strong>{{ draft.intro || '-' }}</div>
+              <div class="text-body-2 mb-2"><strong>难度：</strong>{{ draft.rank || 3 }}</div>
+              <div class="text-body-2 mb-2"><strong>分类ID：</strong>{{ draft.categoryId ?? '-' }}</div>
+              <div class="text-body-2 mb-2"><strong>话题ID：</strong>{{ (draft.topics || []).join(', ') || '-' }}</div>
+              <div class="text-body-2 mb-2">
+                <strong>报名开始：</strong>{{ formatTimestamp(draft.registrationStartAt) }}
+              </div>
+              <div class="text-body-2 mb-2"><strong>截止时间：</strong>{{ formatTimestamp(draft.deadline) }}</div>
+              <div class="text-body-2"><strong>默认完成期限：</strong>{{ draft.defaultDeadline || 365 }} 天</div>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-card-text>
+
+      <v-card-actions class="px-4 pb-4 pt-0 d-flex justify-end">
+        <v-btn variant="text" :disabled="pdfConfirmLoading" @click="clearPdfDrafts">清空预览</v-btn>
+        <v-btn
+          color="success"
+          :loading="pdfConfirmLoading"
+          :disabled="pdfConfirmLoading"
+          @click="confirmPublishFromPdf"
+        >
+          <v-icon start>mdi-check-circle-outline</v-icon>
+          确认批量发布
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
     <task-form
       v-if="loadedTemplate"
       class="ma-4 pb-4"
@@ -35,6 +139,18 @@ const { t } = useI18n()
 
 const spaceStore = useSpaceStore()
 const { currentSpaceId, templates, classificationTopics, categories } = storeToRefs(spaceStore)
+const pdfFile = ref<File | File[] | null>(null)
+const pdfPreviewLoading = ref(false)
+const pdfConfirmLoading = ref(false)
+const pdfDrafts = ref<Record<string, any>[]>([])
+const pdfTokenUsed = ref<number | null>(null)
+
+const selectedPdf = computed<File | null>(() => {
+  if (Array.isArray(pdfFile.value)) {
+    return pdfFile.value[0] ?? null
+  }
+  return pdfFile.value
+})
 
 // 获取活跃的分类列表
 const activeCategories = computed(() => {
@@ -49,6 +165,14 @@ const preselectedCategoryId = computed(() => {
   const categoryId = Number(categoryParam)
   // 确保分类在活跃分类列表中
   return activeCategories.value.some((cat) => cat.id === categoryId) ? categoryId : undefined
+})
+
+const pdfTemplateIndex = computed(() => {
+  const templateParam = route.query.templateId
+  if (!templateParam || templateParam === 'blank') return -1
+
+  const templateId = Number(templateParam)
+  return Number.isFinite(templateId) ? templateId : -1
 })
 
 const loadedTemplate = ref(false)
@@ -106,6 +230,93 @@ const submitTask = async (taskData: TaskFormSubmitData) => {
   )
 
   return result !== undefined
+}
+
+const previewFromPdf = async () => {
+  const spaceId = currentSpaceId.value
+  if (!spaceId) {
+    toast.error(t('spaces.detail.publishTask.spaceIdNotFound'))
+    return
+  }
+
+  if (!selectedPdf.value) {
+    toast.error('请先选择要上传的 PDF 文件')
+    return
+  }
+
+  if (selectedPdf.value.size > 15 * 1024 * 1024) {
+    toast.error('PDF 文件不能超过 15MB')
+    return
+  }
+
+  pdfPreviewLoading.value = true
+  try {
+    const { data } = await TasksApi.previewFromPdf({
+      spaceId,
+      file: selectedPdf.value,
+      categoryId: preselectedCategoryId.value,
+      templateIndex: pdfTemplateIndex.value,
+      maxTasks: 20,
+    })
+
+    if (!data.drafts || data.drafts.length === 0) {
+      toast.error('未识别到可发布的赛题草稿')
+      pdfDrafts.value = []
+      pdfTokenUsed.value = data.tokenUsed ?? null
+      return
+    }
+
+    pdfDrafts.value = data.drafts
+    pdfTokenUsed.value = data.tokenUsed ?? null
+    toast.success(`解析完成，共识别 ${data.drafts.length} 个赛题草稿`)
+  } catch (error) {
+    console.error('PDF 解析预览失败:', error)
+    toast.error('PDF 解析预览失败')
+  } finally {
+    pdfPreviewLoading.value = false
+  }
+}
+
+const confirmPublishFromPdf = async () => {
+  const spaceId = currentSpaceId.value
+  if (!spaceId) {
+    toast.error(t('spaces.detail.publishTask.spaceIdNotFound'))
+    return
+  }
+  if (pdfDrafts.value.length === 0) {
+    toast.error('没有可发布的草稿，请先解析预览')
+    return
+  }
+
+  pdfConfirmLoading.value = true
+  try {
+    const { data } = await TasksApi.confirmFromPdf({
+      drafts: pdfDrafts.value as any,
+    })
+    toast.success(`已发布 ${data.count || data.tasks.length} 个赛题`)
+    pdfDrafts.value = []
+    pdfTokenUsed.value = null
+    router.replace({ name: 'SpacesDetailMyPublishing', params: { spaceId } })
+  } catch (error) {
+    console.error('PDF 批量发布失败:', error)
+    toast.error('PDF 批量发布失败')
+  } finally {
+    pdfConfirmLoading.value = false
+  }
+}
+
+const clearPdfDrafts = () => {
+  pdfDrafts.value = []
+  pdfTokenUsed.value = null
+}
+
+const formatTimestamp = (value: number | string | null | undefined) => {
+  if (!value) return '-'
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return '-'
+  const date = new Date(numeric)
+  if (Number.isNaN(date.getTime())) return '-'
+  return date.toLocaleString('zh-CN', { hour12: false })
 }
 
 onMounted(async () => {

--- a/src/views/tasks/Edit.vue
+++ b/src/views/tasks/Edit.vue
@@ -14,6 +14,8 @@
         :submit-button-text="'保存更改'"
         is-editing
         :classification-topics="taskData.space?.classificationTopics || []"
+        :description-format="editTaskData.descriptionFormat"
+        :original-description="editTaskData.originalDescription"
         @submit="handleSubmitEdit"
         @cancel="navigateToDetail"
       >

--- a/src/views/tasks/composables/useTaskData.ts
+++ b/src/views/tasks/composables/useTaskData.ts
@@ -54,6 +54,52 @@ export function useTaskData() {
     return null
   })
 
+  /** 判断是否为 TipTap JSON 格式 */
+  const isTipTapJson = (raw: string): boolean => {
+    if (!raw) return false
+    try {
+      const parsed = JSON.parse(raw)
+      return typeof parsed === 'object' && parsed !== null && parsed.type === 'doc'
+    } catch {
+      return false
+    }
+  }
+
+  /** 解析描述内容，支持 TipTap JSON 和 Markdown 格式 */
+  const parseDescription = (raw: string): any => {
+    if (!raw) return { type: 'doc', content: [] }
+    if (isTipTapJson(raw)) {
+      try {
+        return JSON.parse(raw)
+      } catch {
+        return { type: 'doc', content: [] }
+      }
+    }
+    // 如果是 markdown 格式，返回包含 markdown 内容的文档结构
+    return {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: raw,
+            },
+          ],
+        },
+      ],
+    }
+  }
+
+  /** 判断描述内容的原始格式 */
+  const getDescriptionFormat = (raw: string): 'markdown' | 'tiptap' => {
+    if (isTipTapJson(raw)) {
+      return 'tiptap'
+    }
+    return 'markdown'
+  }
+
   const editTaskData = computed(() => {
     if (!taskData.value) return {}
     return {
@@ -67,7 +113,9 @@ export function useTaskData() {
       deadline: new Date(taskData.value.deadline).getTime(),
       resubmittable: taskData.value.resubmittable,
       editable: taskData.value.editable,
-      description: JSON.parse(taskData.value.description),
+      description: parseDescription(taskData.value.description),
+      descriptionFormat: getDescriptionFormat(taskData.value.description),
+      originalDescription: taskData.value.description,
       requireRealName: taskData.value.requireRealName,
       minTeamSize: taskData.value.minTeamSize,
       maxTeamSize: taskData.value.maxTeamSize,

--- a/src/views/tasks/composables/useTaskData.ts
+++ b/src/views/tasks/composables/useTaskData.ts
@@ -74,6 +74,7 @@ export function useTaskData() {
       participantLimit: taskData.value.participantLimit,
       teamLockingPolicy: taskData.value.teamLockingPolicy,
       categoryId: taskData.value.category?.id,
+      videoUrl: taskData.value.videoUrl || '',
     }
   })
 

--- a/src/views/tasks/detail/Overview.vue
+++ b/src/views/tasks/detail/Overview.vue
@@ -204,7 +204,7 @@
         </v-card>
 
         <!-- 赛题视频 -->
-        <v-card v-if="taskData?.videoUrl" flat rounded="lg" class="mt-4 task-info-card" border="sm">
+        <v-card v-if="sanitizedVideoUrl" flat rounded="lg" class="mt-4 task-info-card" border="sm">
           <v-card-item>
             <template #prepend>
               <div class="me-3">
@@ -226,7 +226,7 @@
               />
               <div v-else class="d-flex align-center gap-2">
                 <v-icon color="primary">mdi-open-in-new</v-icon>
-                <a :href="taskData.videoUrl" target="_blank" rel="noopener">{{ taskData.videoUrl }}</a>
+                <a :href="sanitizedVideoUrl" target="_blank" rel="noopener">{{ sanitizedVideoUrl }}</a>
               </div>
             </div>
           </v-card-text>
@@ -461,6 +461,21 @@ const renderedMarkdown = computed(() => {
 
 const rankStars = computed(() => {
   return props.taskData?.rank ? props.taskData.rank : 0
+})
+
+/** 校验 videoUrl 是否为安全的 HTTP(S) 协议，防止 javascript:/data: XSS */
+const sanitizedVideoUrl = computed(() => {
+  const url = props.taskData?.videoUrl
+  if (!url) return null
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return url
+    }
+  } catch {
+    // invalid URL
+  }
+  return null
 })
 
 const videoEmbedUrl = computed(() => {

--- a/src/views/tasks/detail/Overview.vue
+++ b/src/views/tasks/detail/Overview.vue
@@ -400,6 +400,7 @@ import { MarkdownRenderer } from '@/components/chat/services/markdownRenderer'
 import { TaskParticipationInfo } from '@/network/api/tasks/types'
 import AccountService from '@/services/account'
 
+/** Markdown 渲染器实例，用于将非 TipTap 格式的赛题描述渲染为 HTML */
 const markdownRenderer = new MarkdownRenderer()
 
 const TipTapViewer = defineAsyncComponent(() => import('@/components/common/Editor/TipTapViewer.vue'))
@@ -429,6 +430,7 @@ const isSelfTask = computed(() => {
   return props.taskData?.creator.id === AccountService.user?.id
 })
 
+/** 判断赛题描述是否为 TipTap JSON 格式（包含 type: 'doc' 的对象） */
 const isTipTapJson = computed(() => {
   const raw = props.taskData?.description ?? ''
   if (!raw) return false
@@ -441,6 +443,7 @@ const isTipTapJson = computed(() => {
   }
 })
 
+/** 解析 TipTap JSON 内容，解析失败时返回空文档结构 */
 const tipTapContent = computed(() => {
   try {
     return JSON.parse(props.taskData?.description ?? '{}')
@@ -449,6 +452,7 @@ const tipTapContent = computed(() => {
   }
 })
 
+/** 将非 TipTap 格式的赛题描述作为 Markdown 渲染为 HTML，TipTap 格式时返回空字符串 */
 const renderedMarkdown = computed(() => {
   const raw = props.taskData?.description ?? ''
   if (!raw || isTipTapJson.value) return ''

--- a/src/views/tasks/detail/Overview.vue
+++ b/src/views/tasks/detail/Overview.vue
@@ -202,6 +202,36 @@
             </div>
           </v-card-text>
         </v-card>
+
+        <!-- 赛题视频 -->
+        <v-card v-if="taskData?.videoUrl" flat rounded="lg" class="mt-4 task-info-card" border="sm">
+          <v-card-item>
+            <template #prepend>
+              <div class="me-3">
+                <v-avatar color="primary-lighten-5" size="48" class="elevation-0">
+                  <v-icon color="primary" size="28">mdi-video-outline</v-icon>
+                </v-avatar>
+              </div>
+            </template>
+            <v-card-title class="text-h5 ps-0">赛题视频</v-card-title>
+          </v-card-item>
+          <v-card-text>
+            <div class="video-container">
+              <iframe
+                v-if="videoEmbedUrl"
+                :src="videoEmbedUrl"
+                frameborder="0"
+                allowfullscreen
+                style="width: 100%; aspect-ratio: 16/9; border-radius: 8px"
+              />
+              <div v-else class="d-flex align-center gap-2">
+                <v-icon color="primary">mdi-open-in-new</v-icon>
+                <a :href="taskData.videoUrl" target="_blank" rel="noopener">{{ taskData.videoUrl }}</a>
+              </div>
+            </div>
+          </v-card-text>
+        </v-card>
+
         <v-card flat rounded="lg" class="mt-4 task-info-card" border="sm">
           <v-card-item>
             <template #prepend>
@@ -427,6 +457,25 @@ const renderedMarkdown = computed(() => {
 
 const rankStars = computed(() => {
   return props.taskData?.rank ? props.taskData.rank : 0
+})
+
+const videoEmbedUrl = computed(() => {
+  const url = props.taskData?.videoUrl
+  if (!url) return null
+
+  // Bilibili: https://www.bilibili.com/video/BVxxxx or https://b23.tv/xxxx
+  const bvMatch = url.match(/bilibili\.com\/video\/(BV[\w]+)/)
+  if (bvMatch) {
+    return `//player.bilibili.com/player.html?bvid=${bvMatch[1]}&autoplay=0`
+  }
+
+  // YouTube: https://www.youtube.com/watch?v=xxxx or https://youtu.be/xxxx
+  const ytMatch = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([\w-]+)/)
+  if (ytMatch) {
+    return `//www.youtube.com/embed/${ytMatch[1]}`
+  }
+
+  return null
 })
 
 const taskUserDeadline = computed(() => {

--- a/src/views/tasks/detail/Overview.vue
+++ b/src/views/tasks/detail/Overview.vue
@@ -196,7 +196,9 @@
 
           <v-card-text>
             <div class="task-description">
-              <TipTapViewer :value="taskDescription" />
+              <TipTapViewer v-if="isTipTapJson" :value="tipTapContent" />
+              <div v-else-if="renderedMarkdown" class="markdown-body" v-html="renderedMarkdown" />
+              <p v-else class="text-medium-emphasis">暂无赛题详情</p>
             </div>
           </v-card-text>
         </v-card>
@@ -364,8 +366,11 @@ import dayjs from 'dayjs'
 
 import { getAvatarUrl } from '@/utils/materials'
 
+import { MarkdownRenderer } from '@/components/chat/services/markdownRenderer'
 import { TaskParticipationInfo } from '@/network/api/tasks/types'
 import AccountService from '@/services/account'
+
+const markdownRenderer = new MarkdownRenderer()
 
 const TipTapViewer = defineAsyncComponent(() => import('@/components/common/Editor/TipTapViewer.vue'))
 const CountdownTimer = defineAsyncComponent(() => import('@/components/common/CountdownTimer.vue'))
@@ -394,12 +399,30 @@ const isSelfTask = computed(() => {
   return props.taskData?.creator.id === AccountService.user?.id
 })
 
-const taskDescription = computed(() => {
+const isTipTapJson = computed(() => {
+  const raw = props.taskData?.description ?? ''
+  if (!raw) return false
+  try {
+    const parsed = JSON.parse(raw)
+    // TipTap JSON 是对象且包含 type: 'doc'
+    return typeof parsed === 'object' && parsed !== null && parsed.type === 'doc'
+  } catch {
+    return false
+  }
+})
+
+const tipTapContent = computed(() => {
   try {
     return JSON.parse(props.taskData?.description ?? '{}')
-  } catch (error) {
-    return props.taskData?.description
+  } catch {
+    return {}
   }
+})
+
+const renderedMarkdown = computed(() => {
+  const raw = props.taskData?.description ?? ''
+  if (!raw || isTipTapJson.value) return ''
+  return markdownRenderer.render(raw)
 })
 
 const rankStars = computed(() => {
@@ -460,6 +483,84 @@ const goToAIAdvice = () => {
 .task-description {
   font-size: 1rem;
   line-height: 1.6;
+}
+
+/* Markdown 渲染内容样式 */
+.markdown-body :deep(h1) {
+  font-size: 1.75rem;
+  margin: 1.5rem 0 1rem;
+  font-weight: 700;
+}
+.markdown-body :deep(h2) {
+  font-size: 1.5rem;
+  margin: 1.25rem 0 0.75rem;
+  font-weight: 600;
+}
+.markdown-body :deep(h3) {
+  font-size: 1.25rem;
+  margin: 1rem 0 0.5rem;
+  font-weight: 600;
+}
+.markdown-body :deep(p) {
+  margin: 0.5rem 0;
+}
+.markdown-body :deep(ul),
+.markdown-body :deep(ol) {
+  padding-left: 1.5rem;
+  margin: 0.5rem 0;
+}
+.markdown-body :deep(li) {
+  margin: 0.25rem 0;
+}
+.markdown-body :deep(table) {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1rem 0;
+}
+.markdown-body :deep(th),
+.markdown-body :deep(td) {
+  border: 1px solid rgba(var(--v-border-color), 1);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+}
+.markdown-body :deep(th) {
+  background: rgba(var(--v-theme-primary), 0.06);
+  font-weight: 600;
+}
+.markdown-body :deep(blockquote) {
+  border-left: 4px solid rgb(var(--v-theme-primary));
+  padding: 0.5rem 1rem;
+  margin: 0.75rem 0;
+  background: rgba(var(--v-theme-primary), 0.04);
+  border-radius: 0 4px 4px 0;
+}
+.markdown-body :deep(code) {
+  background: rgba(var(--v-theme-surface-variant), 0.5);
+  padding: 0.125rem 0.375rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+.markdown-body :deep(pre) {
+  background: rgba(var(--v-theme-surface-variant), 0.5);
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 0.75rem 0;
+}
+.markdown-body :deep(pre code) {
+  background: transparent;
+  padding: 0;
+}
+.markdown-body :deep(img) {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 0.75rem 0;
+}
+.markdown-body :deep(hr) {
+  border: none;
+  border-top: 1px solid rgba(var(--v-border-color), 1);
+  margin: 1.5rem 0;
 }
 
 .task-detail-card,

--- a/src/views/tasks/detail/Overview.vue
+++ b/src/views/tasks/detail/Overview.vue
@@ -415,7 +415,7 @@ const tipTapContent = computed(() => {
   try {
     return JSON.parse(props.taskData?.description ?? '{}')
   } catch {
-    return {}
+    return { type: 'doc', content: [] }
   }
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "target": "ESNext",
     "useDefineForClassFields": true,
     "module": "ESNext",


### PR DESCRIPTION
Summary
Add PDF-to-task quick-publish flow and refactor task description rendering.
Changes
PDF quick publish: Upload PDF → preview parsed drafts → batch confirm publish
Task description rendering: Support TipTap JSON, Markdown, and fallback display
Video URL field: Add optional video link to task creation/editing
Security: Validate videoUrl protocol (http/https only) to prevent XSS
Config
New env variable: VITE_PDF_UPLOAD_TIMEOUT_MS (default 600000ms)